### PR TITLE
Update portserial.c

### DIFF
--- a/port/portserial.c
+++ b/port/portserial.c
@@ -220,6 +220,7 @@ static void serial_soft_trans_irq(void* parameter) {
  * @return return RT_EOK
  */
 static rt_err_t serial_rx_ind(rt_device_t dev, rt_size_t size) {
-    prvvUARTRxISR();
+    while(size--)
+        prvvUARTRxISR();
     return RT_EOK;
 }


### PR DESCRIPTION
rtt serial驱动特性  ind回调不是每个字节都能调用一次 
如果modbus 数据帧中间有干扰存在 ，数据缓存在serial 的rx_fifo中  ，rx_ind 无法触发 造成modbus收不到新数据 ，卡死