### PR TITLE
[fix] Fix host deadlock

### DIFF
--- a/port/portevent_m.c
+++ b/port/portevent_m.c
@@ -49,12 +49,16 @@ BOOL
 xMBMasterPortEventGet( eMBMasterEventType * eEvent )
 {
     rt_uint32_t recvedEvent;
+    BOOL result;
     /* waiting forever OS event */
-    rt_event_recv(&xMasterOsEvent,
+    result = rt_event_recv(&xMasterOsEvent,
             EV_MASTER_READY | EV_MASTER_FRAME_RECEIVED | EV_MASTER_EXECUTE |
             EV_MASTER_FRAME_SENT | EV_MASTER_ERROR_PROCESS,
-            RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, RT_WAITING_FOREVER,
+            RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, MB_MASTER_DELAY_MS_CONVERT,
             &recvedEvent);
+
+    if(result != RT_EOK) 
+        return FALSE;
     /* the enum type couldn't convert to int type */
     switch (recvedEvent)
     {
@@ -72,6 +76,9 @@ xMBMasterPortEventGet( eMBMasterEventType * eEvent )
         break;
     case EV_MASTER_ERROR_PROCESS:
         *eEvent = EV_MASTER_ERROR_PROCESS;
+        break;
+    default:
+        *eEvent = EV_MASTER_FRAME_RECEIVED;
         break;
     }
     return TRUE;


### PR DESCRIPTION
本次提交修复了，`modbus` 主机出现死等事件，导致无法正常工作的 `BUG`

1. 修复 `switch case` 语句没有 `default`  的情况，如果从机是无线串口的方式会出现超时响应，则会导致主机停止运行。[详见](https://club.rt-thread.org/ask/question/423726.html)
2. 修复 `xMBMasterPortEventGet` 永远只会返回 `TURE` 的问题
3. `rt_event_recv` 不要支持死等的情况。如果没有从机设备时，主机就会死等事件，导致主机不在工作。主机先启动，从机后启动，这样主机收不到从机的报文，主机死等。从机接入网络，收不到主机的报文，从机死等。这样就是一个恶性循环了。