### PR TITLE
[fix] Hosts should not wait forever for events to arrive

### DIFF
--- a/port/portevent_m.c
+++ b/port/portevent_m.c
@@ -213,13 +213,18 @@ void vMBMasterCBRequestScuuess( void ) {
 eMBMasterReqErrCode eMBMasterWaitRequestFinish( void ) {
     eMBMasterReqErrCode    eErrStatus = MB_MRE_NO_ERR;
     rt_uint32_t recvedEvent;
+    rt_uint32_t result;
     /* waiting for OS event */
-    rt_event_recv(&xMasterOsEvent,
-            EV_MASTER_PROCESS_SUCESS | EV_MASTER_ERROR_RESPOND_TIMEOUT
-                    | EV_MASTER_ERROR_RECEIVE_DATA
-                    | EV_MASTER_ERROR_EXECUTE_FUNCTION,
-            RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, RT_WAITING_FOREVER,
-            &recvedEvent);
+    result = rt_event_recv(&xMasterOsEvent,
+                    EV_MASTER_PROCESS_SUCESS | EV_MASTER_ERROR_RESPOND_TIMEOUT
+                            | EV_MASTER_ERROR_RECEIVE_DATA
+                            | EV_MASTER_ERROR_EXECUTE_FUNCTION,
+                    RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, MB_MASTER_DELAY_MS_CONVERT,
+                    &recvedEvent);
+    if (result != RT_EOK) {
+        eErrStatus = MB_MRE_TIMEDOUT;
+    }
+
     switch (recvedEvent)
     {
     case EV_MASTER_PROCESS_SUCESS:
@@ -239,6 +244,9 @@ eMBMasterReqErrCode eMBMasterWaitRequestFinish( void ) {
         eErrStatus = MB_MRE_EXE_FUN;
         break;
     }
+    default:
+        eErrStatus = MB_MRE_TIMEDOUT;
+        break;
     }
     return eErrStatus;
 }


### PR DESCRIPTION
1. 主机不应该使用 `forever` 的方式去等待事件的到来，这样会导致主机阻塞。主机作为 `modbus` 协议中的通讯发起者，不能出现阻塞的情况，如果网络中有一个从机的响应不正常，主机的阻塞将导致整个网络瘫痪。主机该返回超时时一定要返回超时。
2. 增加 `switch case` 中的 `default` 。这里是 `or` 的方式去等待事件，极限情况下是可能出现同时受到多个事件，同时收到多个事件将导致 `switch case` 解析失败，在该语句中只有一种情况是表示接受成功的，只要接收到2个事件，至少有一个事件是错误事件，因为没有 `default` 的存在，这里依然会返回 `eErrStatus = MB_MRE_NO_ERR`