### PR TITLE
从机超时响应会导致解析失败

### DIFF
--- a/port/portevent_m.c
+++ b/port/portevent_m.c
@@ -51,14 +51,12 @@ xMBMasterPortEventGet( eMBMasterEventType * eEvent )
     rt_uint32_t recvedEvent;
     BOOL result;
     /* waiting forever OS event */
-    result = rt_event_recv(&xMasterOsEvent,
+    rt_event_recv(&xMasterOsEvent,
             EV_MASTER_READY | EV_MASTER_FRAME_RECEIVED | EV_MASTER_EXECUTE |
             EV_MASTER_FRAME_SENT | EV_MASTER_ERROR_PROCESS,
-            RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, MB_MASTER_DELAY_MS_CONVERT,
+            RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, RT_WAITING_FOREVER,
             &recvedEvent);
 
-    if(result != RT_EOK) 
-        return FALSE;
     /* the enum type couldn't convert to int type */
     switch (recvedEvent)
     {


### PR DESCRIPTION
事件等待这里给了一个默认的等待时间，如果从机不是立即响应，而是延迟响应，则会出现解析报文的问题，这里使用永久等待的方式可以一直等到有数据接收到之后再进行数据解析。