### PR TITLE
清除unused编译警告

### DIFF
--- a/port/portevent_m.c
+++ b/port/portevent_m.c
@@ -49,7 +49,7 @@ BOOL
 xMBMasterPortEventGet( eMBMasterEventType * eEvent )
 {
     rt_uint32_t recvedEvent;
-    BOOL result;
+	
     /* waiting forever OS event */
     rt_event_recv(&xMasterOsEvent,
             EV_MASTER_READY | EV_MASTER_FRAME_RECEIVED | EV_MASTER_EXECUTE |

--- a/port/portevent_m.c
+++ b/port/portevent_m.c
@@ -49,7 +49,7 @@ BOOL
 xMBMasterPortEventGet( eMBMasterEventType * eEvent )
 {
     rt_uint32_t recvedEvent;
-	
+
     /* waiting forever OS event */
     rt_event_recv(&xMasterOsEvent,
             EV_MASTER_READY | EV_MASTER_FRAME_RECEIVED | EV_MASTER_EXECUTE |


### PR DESCRIPTION
portevent_m.c文件52行，'result' 定义未使用
编译提示: warning: unused variable 'result'