### PR TITLE
Fix receiving interrupt caused by sending state machine not exiting, …

### DIFF
--- a/modbus/rtu/mbrtu.c
+++ b/modbus/rtu/mbrtu.c
@@ -307,8 +307,8 @@ xMBRTUTransmitFSM( void )
             xNeedPoll = xMBPortEventPost( EV_FRAME_SENT );
             /* Disable transmitter. This prevents another transmit buffer
              * empty interrupt. */
-            vMBPortSerialEnable( TRUE, FALSE );
             eSndState = STATE_TX_IDLE;
+            vMBPortSerialEnable( TRUE, FALSE );
         }
         break;
     }

--- a/modbus/rtu/mbrtu_m.c
+++ b/modbus/rtu/mbrtu_m.c
@@ -325,8 +325,8 @@ xMBMasterRTUTransmitFSM( void )
             xFrameIsBroadcast = ( ucMasterRTUSndBuf[MB_SER_PDU_ADDR_OFF] == MB_ADDRESS_BROADCAST ) ? TRUE : FALSE;
             /* Disable transmitter. This prevents another transmit buffer
              * empty interrupt. */
-            vMBMasterPortSerialEnable( TRUE, FALSE );
             eSndState = STATE_M_TX_XFWR;
+            vMBMasterPortSerialEnable( TRUE, FALSE );
             /* If the frame is broadcast ,master will enable timer of convert delay,
              * else master will enable timer of respond timeout. */
             if ( xFrameIsBroadcast == TRUE )


### PR DESCRIPTION
修复在多线程的系统中发送状态机未退出就产生接收中断，从而导致接收状态机断言报错